### PR TITLE
Change return type

### DIFF
--- a/src/CRC_VCNL4200.cpp
+++ b/src/CRC_VCNL4200.cpp
@@ -103,7 +103,7 @@ void CRC_VCNL4200::write8(uint8_t address, uint8_t data) //Original
 	Wire.endTransmission();
 }
 
-uint8_t CRC_VCNL4200::write16_LowHigh(uint8_t address, uint8_t low, uint8_t high)
+void CRC_VCNL4200::write16_LowHigh(uint8_t address, uint8_t low, uint8_t high)
 {
 	Wire.beginTransmission(_i2caddr);
 	Wire.write(address);

--- a/src/CRC_VCNL4200.h
+++ b/src/CRC_VCNL4200.h
@@ -83,6 +83,6 @@ public:
 private:
 	uint8_t _i2caddr;
 	void write8(uint8_t address, uint8_t data);
-	uint8_t write16_LowHigh(uint8_t address, uint8_t low, uint8_t high);
+	void write16_LowHigh(uint8_t address, uint8_t low, uint8_t high);
 	uint16_t readData(uint8_t command_code);
 };


### PR DESCRIPTION
write16_LowHigh was defined with a uint8_t return type.  However, the function defined in the cpp file does not explicitly return anything.  Furthermore, the returned value is ignored in all uses of write16_LowHigh.  

Changed the return type of write16_LowHigh to void in both the .h and .cpp files.  

As a side note, there is mention of a breakout pcb board available.  However, the parts list does not seem to be provided.  